### PR TITLE
Add package name for cops

### DIFF
--- a/lib/rubocop/formatter/checkstyle_formatter.rb
+++ b/lib/rubocop/formatter/checkstyle_formatter.rb
@@ -32,7 +32,7 @@ module Rubocop
             e.attributes['column'] = offence.column
             e.attributes['severity'] = to_checkstyle_severity(offence.severity)
             e.attributes['message'] = offence.message
-            e.attributes['source'] = offence.cop_name
+            e.attributes['source'] = 'com.puppycrawl.tools.checkstyle.' + offence.cop_name
           end
         end
       end


### PR DESCRIPTION
Please integrate this change. Otherwise the cop name is not listed in the type column Checkstyle reports in Jenkins. It would be possible to use another name space than com.puppycrawl, but this has the added benefit of providing descriptions for some of the more common cops.

This is not my code, I only created a PR from an existing fork.
