### PR TITLE
Fix severity mapping with rubocop 0.21+

### DIFF
--- a/lib/rubocop/formatter/checkstyle_formatter.rb
+++ b/lib/rubocop/formatter/checkstyle_formatter.rb
@@ -30,7 +30,7 @@ module Rubocop
           REXML::Element.new('error', parent).tap do |e|
             e.attributes['line'] = offence.line
             e.attributes['column'] = offence.column
-            e.attributes['severity'] = to_checkstyle_severity(offence.severity)
+            e.attributes['severity'] = to_checkstyle_severity(offence.severity.to_s)
             e.attributes['message'] = offence.message
             e.attributes['source'] = 'com.puppycrawl.tools.checkstyle.' + offence.cop_name
           end
@@ -40,10 +40,10 @@ module Rubocop
       # TODO be able to configure severity mapping
       def to_checkstyle_severity(rubocop_severity)
         case rubocop_severity
-        when :fatal, :error; 'error'
-        when :warning; 'warning'
-        when :convention, :refactor; 'info'
-        else; 'warning'
+        when 'fatal', 'error' then 'error'
+        when 'warning' then 'warning'
+        when 'convention', 'refactor' then 'info'
+        else 'warning'
         end
       end
     end


### PR DESCRIPTION
offense.severity is now an instance of Rubocop::Cop::Severity, so we need to convert it to a string first.
This should be fully backwards compatible.
