### PR TITLE
Rename module name from Rubocop to RuboCop to follow RuboCop gem update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rubocop Checkstyle Formatter
+# RuboCop Checkstyle Formatter
 
 A formatter for rubocop that outputs in checkstyle format.
 It requires rubocop version 0.9.0 or above.
@@ -21,12 +21,12 @@ Or install it yourself as:
 
 ## Usage
 
-    $ rubocop --require rubocop/formatter/checkstyle_formatter --format Rubocop::Formatter::CheckstyleFormatter
+    $ rubocop --require rubocop/formatter/checkstyle_formatter --format RuboCop::Formatter::CheckstyleFormatter
     
 I use this formatter in Jenkins with [Violations plugin](https://wiki.jenkins-ci.org/display/JENKINS/Violations).
 As a part of build, I execute rubocop as shell script like:
 
-    bundle exec rubocop --require rubocop/formatter/checkstyle_formatter --format Rubocop::Formatter::CheckstyleFormatter --no-color --silent --rails --out tmp/checkstyle.xml
+    bundle exec rubocop --require rubocop/formatter/checkstyle_formatter --format RuboCop::Formatter::CheckstyleFormatter --no-color --silent --rails --out tmp/checkstyle.xml
 
 Then, after build, I add 'Report Violations' and configure xml filename pattern of checkstyle to "tmp/checkstyle.xml".
 

--- a/lib/rubocop/formatter/checkstyle_formatter.rb
+++ b/lib/rubocop/formatter/checkstyle_formatter.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 require 'rexml/document'
 
-module Rubocop
+module RuboCop
   module Formatter
     # = This formatter reports in Checkstyle format.
     class CheckstyleFormatter < BaseFormatter

--- a/rubocop-checkstyle_formatter.gemspec
+++ b/rubocop-checkstyle_formatter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'rubocop', '>= 0.14.0'
+  gem.add_dependency 'rubocop', '>= 0.23.0'
   gem.add_development_dependency 'appraisal', '~> 1.0.0'
   gem.add_development_dependency 'bundler', '~> 1.3'
   gem.add_development_dependency 'rake', '~> 10.1'

--- a/spec/rubocop/formatter/checkstyle_formatter_spec.rb
+++ b/spec/rubocop/formatter/checkstyle_formatter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'stringio'
 require 'rexml/document'
 
-module Rubocop
+module RuboCop
   module Formatter
     describe CheckstyleFormatter do
       let(:severities) { [:refactor, :convention, :warning, :error, :fatal] }


### PR DESCRIPTION
Rubocop module name has changed from following commit.

Rename Rubocop module to RuboCop
- https://github.com/bbatsov/rubocop/commit/ff167d8f202baf7a68955db0aaf0dc29afb7e7ee
