### PR TITLE
Adding relative path for filename

### DIFF
--- a/lib/rubocop/formatter/checkstyle_formatter.rb
+++ b/lib/rubocop/formatter/checkstyle_formatter.rb
@@ -8,7 +8,7 @@ module RuboCop
   module Formatter
     # = This formatter reports in Checkstyle format.
     class CheckstyleFormatter < BaseFormatter
-      include PathUtil
+      include PathUtil if defined?(PathUtil)
       def started(target_file)
         @document = REXML::Document.new.tap do |d|
           d << REXML::XMLDecl.new
@@ -18,7 +18,11 @@ module RuboCop
 
       def file_finished(file, offences)
         REXML::Element.new('file', @checkstyle).tap do |f|
-          f.attributes['name'] = relative_path(file)
+          path_name = file
+          path_name = relative_path(file) if defined?(relative_path)
+
+          f.attributes['name'] = path_name
+
           add_offences(f, offences)
         end
       end

--- a/lib/rubocop/formatter/checkstyle_formatter.rb
+++ b/lib/rubocop/formatter/checkstyle_formatter.rb
@@ -8,6 +8,7 @@ module RuboCop
   module Formatter
     # = This formatter reports in Checkstyle format.
     class CheckstyleFormatter < BaseFormatter
+      include PathUtil
       def started(target_file)
         @document = REXML::Document.new.tap do |d|
           d << REXML::XMLDecl.new
@@ -17,7 +18,7 @@ module RuboCop
 
       def file_finished(file, offences)
         REXML::Element.new('file', @checkstyle).tap do |f|
-          f.attributes['name'] = file
+          f.attributes['name'] = relative_path(file)
           add_offences(f, offences)
         end
       end

--- a/rubocop-checkstyle_formatter.gemspec
+++ b/rubocop-checkstyle_formatter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'rubocop', '>= 0.14.0'
+  gem.add_dependency 'rubocop', '>= 0.30.0'
   gem.add_development_dependency 'appraisal', '~> 1.0.0'
   gem.add_development_dependency 'bundler', '~> 1.3'
   gem.add_development_dependency 'rake', '~> 10.1'

--- a/rubocop-checkstyle_formatter.gemspec
+++ b/rubocop-checkstyle_formatter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'rubocop', '>= 0.30.0'
+  gem.add_dependency 'rubocop', '>= 0.14.0'
   gem.add_development_dependency 'appraisal', '~> 1.0.0'
   gem.add_development_dependency 'bundler', '~> 1.3'
   gem.add_development_dependency 'rake', '~> 10.1'


### PR DESCRIPTION
The standard formatters for rubocop use the relative_path utility, for example on the json formatter:
https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/formatter/json_formatter.rb#L49

This is super helpful in Jenkins.