### PR TITLE
Require the base_formatter before using it

### DIFF
--- a/lib/rubocop/formatter/checkstyle_formatter.rb
+++ b/lib/rubocop/formatter/checkstyle_formatter.rb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 require 'rexml/document'
+require 'rubocop/formatter/base_formatter'
 
 # XXX: Renamed to RuboCop since 0.23.0
 RuboCop = Rubocop if defined?(Rubocop) && ! defined?(RuboCop)


### PR DESCRIPTION
This fixes an issue when using the rubocop rake task:
```
rake aborted!
NameError: uninitialized constant RuboCop::Formatter::BaseFormatter
```