### PR TITLE
issue_9: fix to output absolute path

### DIFF
--- a/lib/rubocop/formatter/checkstyle_formatter.rb
+++ b/lib/rubocop/formatter/checkstyle_formatter.rb
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 require 'rexml/document'
 require 'rubocop/formatter/base_formatter'
+require 'pry'
 
 # XXX: Renamed to RuboCop since 0.23.0
 RuboCop = Rubocop if defined?(Rubocop) && ! defined?(RuboCop)
@@ -19,8 +20,7 @@ module RuboCop
 
       def file_finished(file, offences)
         REXML::Element.new('file', @checkstyle).tap do |f|
-          path_name = file
-          path_name = relative_path(file) if defined?(relative_path)
+          path_name = File.expand_path file
           f.attributes['name'] = path_name
           # f.attributes['name'] =
             # defined?(PathUtil) ? PathUtil.relative_path(file) : file

--- a/lib/rubocop/formatter/checkstyle_formatter.rb
+++ b/lib/rubocop/formatter/checkstyle_formatter.rb
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 require 'rexml/document'
 require 'rubocop/formatter/base_formatter'
-require 'pry'
 
 # XXX: Renamed to RuboCop since 0.23.0
 RuboCop = Rubocop if defined?(Rubocop) && ! defined?(RuboCop)

--- a/spec/rubocop/formatter/checkstyle_formatter_spec.rb
+++ b/spec/rubocop/formatter/checkstyle_formatter_spec.rb
@@ -37,7 +37,7 @@ module RuboCop
         doc = REXML::Document.new(output.string)
         REXML::XPath.match(doc, '/checkstyle/file').each do |file|
           if defined?(PathUtil)
-            expect(file.attribute('name').value).to eq('sample.rb')
+            expect(file.attribute('name').value).to eq( File.join(Dir.pwd, 'sample.rb') )
           end
           REXML::XPath.match(file, '/error').each do |error|
             message = error.attribute('message').value


### PR DESCRIPTION
fixed for the issue below.
https://github.com/eitoball/rubocop-checkstyle_formatter/issues/9

<(_ _)>