### PR TITLE
Exclude files without violations from the report

### DIFF
--- a/lib/rubocop/formatter/checkstyle_formatter.rb
+++ b/lib/rubocop/formatter/checkstyle_formatter.rb
@@ -18,6 +18,7 @@ module RuboCop
       end
 
       def file_finished(file, offences)
+        return if offences.empty?
         REXML::Element.new('file', @checkstyle).tap do |f|
           path_name = file
           path_name = relative_path(path_name) if !ENV.has_key?('RUBOCOP_CHECKSTYLE_FORMATTER_ABSOLUTE_PATH') && defined?(relative_path)


### PR DESCRIPTION
Jenkins plugin "Violation Comments to Bitbucket Server" for some reason handles empty xml file tag in a wrong way

To fix this issue this PR excludes files without violations from the report
