### PR TITLE
Exclude spec files from gem package

### DIFF
--- a/rubocop-checkstyle_formatter.gemspec
+++ b/rubocop-checkstyle_formatter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/eitoball/rubocop-checkstyle_formatter'
   gem.license       = 'MIT'
 
-  gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep_v(%r{^spec/})
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']


### PR DESCRIPTION
Here's a patch that excludes files under spec directory from the gem package.

With this patch, the gem package size shrinks as follows:
```
before: 10240 bytes
after:  9728 bytes
```